### PR TITLE
Add Django 2.0 to tests and update tox.ini and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - deadsnakes
     packages:
     - python2.7
-    - python3.4
     - python3.5
     - python3.6
 
@@ -21,30 +20,24 @@ language: python
 # The version of Python that'll be used to invoke tox. Has no effect
 # on what version of Python tox uses to run each set of tests.
 python:
-  - "3.5"
+  - "3.6"
 
 # Test a sampling of combinations
 env:
-  - TOXENV=py27-1.7
   - TOXENV=py27-1.8
   - TOXENV=py27-1.10
   - TOXENV=py27-1.11
-  - TOXENV=py34-1.7
-  - TOXENV=py34-1.8
-  - TOXENV=py34-1.11
-  - TOXENV=py35-1.9
+  - TOXENV=py35-1.8
   - TOXENV=py35-1.10
   - TOXENV=py35-1.11
+  - TOXENV=py35-2.0
   - TOXENV=py36-1.8
   - TOXENV=py36-1.10
   - TOXENV=py36-1.11
+  - TOXENV=py36-2.0
 
 install:
   - pip install tox
 
 script:
   - tox
-#
-#matrix:
-#  allow_failures:
-#    - env: TOXENV=py27-trunk,py33-trunk

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,24 @@
 [tox]
-envlist = py27-{1.5,1.6},
-          {py27,py34}-{1.7,1.8},
-          {py27,py35,py36}-{1.8,1.9,1.10,1.11},
+envlist = {py27,py35,py36}-{1.8,1.10,1.11},
+          {py35,py36}-{2.0},
           docs
 
 [testenv]
 commands = {envpython} -Wmodule runtests.py
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 deps =
-    1.5: Django>=1.5,<1.6
-    1.6: Django>=1.6,<1.7
-    1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
-    1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
     1.11: Django>=1.11,<2.0
+    2.0: Django>=2.0,<2.1
 
 [testenv:docs]
-basepython = python3.4
-deps = Sphinx==1.3.4
+basepython = python3.6
+deps =
+    Sphinx==1.3.4
     caktus-sphinx-theme==0.1.0
 commands =
     {envbindir}/sphinx-build -a -n -b html -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
Update to match versions mentioned in README:
Python 2.7, 3.5+, Django 1.8+ (supported), and add Django 2.0.
