### PR TITLE
Fix parsing of emails for whitelist

### DIFF
--- a/bandit/backends/base.py
+++ b/bandit/backends/base.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 
+from email.utils import parseaddr
 from functools import reduce
 from operator import and_
 
@@ -31,7 +32,8 @@ class HijackBackendMixin(object):
                               [email for name, email in admins])
 
         def is_approved(email):
-            local_part, _, domain = email.rpartition('@')
+            _, email = parseaddr(email)
+            _, _, domain = email.rpartition('@')
             return email in approved_emails or domain in whitelist_emails
 
         to_send = []

--- a/bandit/tests.py
+++ b/bandit/tests.py
@@ -176,7 +176,7 @@ class HijackBackendTestCase(BaseBackendTestCase):
         num_sent = self.get_connection().send_messages(emails)
         self.assertEqual(len(emails), num_sent)
         messages = self.get_mailbox_content()
-        self.assertEqual(messages[0].get_all('to').replace('\n', ''), [', '.join(addresses)])
+        self.assertEqual(messages[0].get_all('to')[0].replace('\n', ''), ', '.join(addresses))
 
 
 class LogOnlyBackendTestCase(BaseBackendTestCase):

--- a/bandit/tests.py
+++ b/bandit/tests.py
@@ -169,7 +169,9 @@ class HijackBackendTestCase(BaseBackendTestCase):
         self.assertEqual(message.get_all('to'), ['admin@example.com', ])
 
     def test_whitelist_domain(self):
-        addresses = ['foo@whitelisted.test.com', 'bar@whitelisted.test.com']
+        addresses = ['foo@whitelisted.test.com',
+                     '<bar@whitelisted.test.com>',
+                     'Foo Bar <baz@whitelisted.test.com>']
         emails = [EmailMessage( 'Subject', 'Content', 'from@example.com', addresses)]
         num_sent = self.get_connection().send_messages(emails)
         self.assertEqual(len(emails), num_sent)

--- a/bandit/tests.py
+++ b/bandit/tests.py
@@ -176,7 +176,7 @@ class HijackBackendTestCase(BaseBackendTestCase):
         num_sent = self.get_connection().send_messages(emails)
         self.assertEqual(len(emails), num_sent)
         messages = self.get_mailbox_content()
-        self.assertEqual(messages[0].get_all('to'), [', '.join(addresses)])
+        self.assertEqual(messages[0].get_all('to').replace('\n', ''), [', '.join(addresses)])
 
 
 class LogOnlyBackendTestCase(BaseBackendTestCase):

--- a/runtests.py
+++ b/runtests.py
@@ -31,14 +31,13 @@ if not settings.configured:
 
 
 def runtests():
-    if django.VERSION > (1, 7):
-        # http://django.readthedocs.org/en/latest/releases/1.7.html#standalone-scripts
-        django.setup()
+    django.setup()
     from django.test.utils import get_runner
     TestRunner = get_runner(settings)
     test_runner = TestRunner(verbosity=1, interactive=True, failfast=True)
-    failures = test_runner.run_tests(['bandit', ])
+    failures = test_runner.run_tests(['bandit'])
     sys.exit(failures)
+
 
 if __name__ == '__main__':
     runtests(*sys.argv[1:])


### PR DESCRIPTION
Addresses enclosed in angled brackets or also including a realname were not supported.

This parses the email address using the standard lib `parseaddr`, then `rpartition` the email to get the domain. Only then is the check performed.
Added tests for such email addresses.

Also remove check for Django version in runtests.