### PR TITLE
Allow BANDIT_EMAIL to be a list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,10 @@ and set the email which will receive all of the emails::
 
     BANDIT_EMAIL = 'bandit@example.com'
 
+or even multiple addresses:
+
+    BANDIT_EMAIL = ['bandit@example.com', 'accomplice@example.com']
+
 It's also possible to whitelist certain email addresses and domains::
 
     BANDIT_WHITELIST = [

--- a/bandit/backends/base.py
+++ b/bandit/backends/base.py
@@ -4,7 +4,6 @@ import logging
 
 from email.utils import parseaddr
 from functools import reduce
-from operator import and_
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -42,7 +41,7 @@ class HijackBackendMixin(object):
         logged_count = 0
         for message in email_messages:
             recipients = message.to + message.cc + message.bcc
-            all_approved = reduce(and_, map(is_approved, recipients))
+            all_approved = all(map(is_approved, recipients))
             if all_approved:
                 to_send.append(message)
             else:

--- a/bandit/backends/base.py
+++ b/bandit/backends/base.py
@@ -27,8 +27,10 @@ class HijackBackendMixin(object):
         admins = getattr(settings, 'ADMINS', ())
         server_email = getattr(settings, 'SERVER_EMAIL', 'root@localhost')
         bandit_email = getattr(settings, 'BANDIT_EMAIL', server_email)
+        if not isinstance(bandit_email, list):
+            bandit_email = [bandit_email]
         whitelist_emails = set(getattr(settings, 'BANDIT_WHITELIST', ()))
-        approved_emails = set([server_email, bandit_email, ] + list(whitelist_emails) +
+        approved_emails = set([server_email] + bandit_email + list(whitelist_emails) +
                               [email for name, email in admins])
 
         def is_approved(email):
@@ -54,7 +56,7 @@ class HijackBackendMixin(object):
                 if not self.log_only:
                     header = render_to_string("bandit/hijacked-email-header.txt", context)
                     message.body = header + message.body
-                    message.to = [bandit_email]
+                    message.to = bandit_email
                     # clear cc/bcc
                     message.cc = []
                     message.bcc = []

--- a/bandit/backends/smtp.py
+++ b/bandit/backends/smtp.py
@@ -16,6 +16,7 @@ class HijackSMTPBackend(HijackBackendMixin, SMTPBackend):
 class LogOnlySMTPBackend(LogOnlyBackendMixin, SMTPBackend):
     """
     This backend intercepts outgoing messages and logs them, allowing
-    only messages destined for ADMINS to be sent via SMTP.
+    only messages destined for ADMINS, BANDIT_EMAIL, SERVER_EMAIL, or
+    BANDIT_WHITELIST to be sent via SMTP.
     """
     pass

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -12,6 +12,10 @@ This defaults to the ``SERVER_EMAIL`` setting if not set::
 
     BANDIT_EMAIL = 'bandit@example.com'
 
+This option can also be a list to send the hijacked email to multiple addresses::
+
+    BANDIT_EMAIL = ['bandit@example.com', 'accomplice@example.com']
+
 
 ``BANDIT_WHITELIST``
 ----------------------------------------


### PR DESCRIPTION
Inspired by #7, but implemented differently to actually work.

Added tests for bandit_email as a list.
Also add other missing tests and clarify some code.