### PR TITLE
Prevent conflicts with e-mail backends where send_messages() return lists

### DIFF
--- a/bandit/backends/base.py
+++ b/bandit/backends/base.py
@@ -79,6 +79,8 @@ class HijackBackendMixin(object):
                     # can report them as sent to the caller
                     logged_count += 1
         sent_count = super().send_messages(to_send) or 0
+        # attempt to workaround backends like django-celery-email that return a list instead of
+        # a count: https://github.com/pmclanahan/django-celery-email/pull/69
         return logged_count + (len(sent_count) if hasattr(sent_count, "__len__") else sent_count)
 
 

--- a/bandit/backends/base.py
+++ b/bandit/backends/base.py
@@ -79,7 +79,7 @@ class HijackBackendMixin(object):
                     # can report them as sent to the caller
                     logged_count += 1
         sent_count = super().send_messages(to_send) or 0
-        return sent_count + logged_count
+        return logged_count + (len(sent_count) if hasattr(sent_count, "__len__") else sent_count)
 
 
 class LogOnlyBackendMixin(HijackBackendMixin):


### PR DESCRIPTION
I assume you've noticed that 3rd party Django mail backends have poor compliance with Django's spec for `send_messages()` to return the _number_ of  e-mails that were sent.

I see that backends that return unexpected things like `None` (like [django-post-office](https://github.com/ui/django-post_office/blob/v3.2.0/post_office/backends.py#L17) does) are already handled by the code.

However, there are also popular backends like [django-celery-email](https://github.com/pmclanahan/django-celery-email/blob/2.0.1/djcelery_email/backends.py#L13) that return a different kind of unexpected value: a list of Celery [AsyncResult](https://docs.celeryproject.org/en/latest/reference/celery.result.html#celery.result.AsyncResult) objects, which can then be used to monitor the sending progress, if desired.

It appears that this incompatibility [has been pointed out](https://github.com/pmclanahan/django-celery-email/pull/69) to the developers, and they appear a bit ambivalent about their intent to fix it. Kinda understandable, since there are probably users out that are reliant on this non-standard behaviour, and they test for it in their tests.

So since it's unlikely that it will be fixed on their end, it's probably justified to add handling for yet another kind of non-standard behaviour. Since the length of a received list is likely to correspond to the number of e-mails that were sent, I propose checking if  the returned object has a length, and using that.

I should add that the impact of this incompatibility isn't actually that bad when django-post-office is also used in the project. What happens then is that the e-mails get sent, but their status gets marked as "failed" and the "can only concatenate list (not "int") to list" error message is placed in the email log. Without it, the `TypeError` would end up propagating, possibly resulting in a 500, though the e-mails should still get sent.