### PR TITLE
Run test-lint action on pull requests to the develop branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,8 @@ name: lint-test
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+    branches:
+      - develop
   push:
     branches:
       - master


### PR DESCRIPTION
This works, but only if PRs are targeting the develop branch (which should be the majority of PRs anyway).

See it work here: https://github.com/jaap3/django-email-bandit/pull/1 (and probably in this PR as well :))